### PR TITLE
Update to latest sdk

### DIFF
--- a/adapters/avail/Cargo.toml
+++ b/adapters/avail/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
-name = "presence"
-version = "0.1.0"
-edition = "2021"
+name = "sov-avail-adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+publish.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 borsh = { workspace = true, features = ["bytes"] }

--- a/adapters/avail/README.md
+++ b/adapters/avail/README.md
@@ -1,38 +1,8 @@
 # Avail Sovereign DA adapter (presence)
 
-Presence is a _research-only_ adapter making Avail compatible with the Sovereign SDK.
+This is a _research-only_ adapter making Avail compatible with the Sovereign SDK.
 
 > **_NOTE:_** None of its code is suitable for production use.
 
-### The DaVerifier Trait
-
-The DaVerifier trait is the simpler of the two core traits. Its job is to take a list of BlobTransactions from a DA layer block
-and verify that the list is _complete_ and _correct_. Once deployed in a rollup, the data verified by this trait
-will be passed to the state transition function, so non-determinism should be strictly avoided.
-
-The logic inside this trait will get compiled down into your rollup's proof system, so it's important to have a high
-degree of confidence in its correctness (upgrading SNARKs is hard!) and think carefully about performance.
-
-At a bare minimum, you should ensure that the verifier rejects...
-
-1. If the order of the blobs in an otherwise valid input is changed
-1. If the sender of any of the blobs is tampered with
-1. If any blob is omitted
-1. If any blob is duplicated
-1. If any extra blobs are added
-
-For compatibility, we also recommend (but don't require) that any logic in the `DaVerifier` be able to build with `no_std`.
-This maximizes your odds of being compatible with any given zk proof system.
-
-### The DaService Trait
-
-The `DaService` trait is slightly more complicated than the `DaVerifier`. Thankfully, it exists entirely outside of the
-rollup's state machine - so it never has to be proven in zk. This means that its perfomance is less critical, and that
-upgrading it in response to a vulnerability is much easier.
-
-The job of the `DAService` is to allow the Sovereign SDK's node software to communicate with a DA layer. It has two related
-responsibilities. The first is to interact with DA layer nodes via RPC - retrieving data for the rollup as it becomes
-available. The second is to process that data into the form expected by the `DaVerifier`. For example, almost all DA layers
-provide data in JSON format via RPC - but, parsing JSON in a zk-SNARK would be horribly inefficient. So, the `DaService`
-is responsible for both querying the RPC service and transforming its responses into a more useful format.
-
+This adapter was originally written by Vibhu Rhajeev and the Avail team, but is
+provided as part of the Sovereign SDK under the Apache 2.0 and MIT licenses.

--- a/adapters/avail/src/spec/address.rs
+++ b/adapters/avail/src/spec/address.rs
@@ -1,6 +1,6 @@
 use core::fmt::{Display, Formatter};
-use std::str::FromStr;
 use std::hash::Hash;
+use std::str::FromStr;
 
 use primitive_types::H256;
 use serde::{Deserialize, Serialize};
@@ -31,10 +31,9 @@ impl From<[u8; 32]> for AvailAddress {
 
 impl FromStr for AvailAddress {
     type Err = <H256 as FromStr>::Err;
-    
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let h_256 = H256::from_str(s)?;
-
 
         Ok(Self(h_256.to_fixed_bytes()))
     }

--- a/adapters/avail/src/spec/block.rs
+++ b/adapters/avail/src/spec/block.rs
@@ -1,7 +1,7 @@
+use crate::verifier::ChainValidityCondition;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::services::da::SlotData;
-use crate::verifier::ChainValidityCondition;
 
 use super::header::AvailHeader;
 use super::transaction::AvailBlobTransaction;
@@ -17,7 +17,7 @@ impl SlotData for AvailBlock {
     type Cond = ChainValidityCondition;
 
     fn hash(&self) -> [u8; 32] {
-        self.header.hash().0.0
+        self.header.hash().0 .0
     }
 
     fn header(&self) -> &Self::BlockHeader {

--- a/adapters/avail/src/spec/hash.rs
+++ b/adapters/avail/src/spec/hash.rs
@@ -2,7 +2,7 @@ use primitive_types::H256;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHashTrait;
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 pub struct AvailHash(pub H256);
 
 impl BlockHashTrait for AvailHash {}
@@ -10,6 +10,12 @@ impl BlockHashTrait for AvailHash {}
 impl AsRef<[u8]> for AvailHash {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl From<AvailHash> for [u8; 32] {
+    fn from(value: AvailHash) -> Self {
+        value.0.to_fixed_bytes()
     }
 }
 

--- a/adapters/avail/src/spec/header.rs
+++ b/adapters/avail/src/spec/header.rs
@@ -4,6 +4,9 @@ use primitive_types::H256;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHeaderTrait;
 
+const KATE_START_TIME: i64 = 1686066440;
+const KATE_SECONDS_PER_BLOCK: i64 = 20;
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
@@ -48,5 +51,15 @@ impl BlockHeaderTrait for AvailHeader {
 
     fn hash(&self) -> Self::Hash {
         self.hash.clone()
+    }
+
+    fn height(&self) -> u64 {
+        self.header.number as u64
+    }
+
+    fn time(&self) -> sov_rollup_interface::da::Time {
+        sov_rollup_interface::da::Time::from_secs(
+            KATE_START_TIME + (self.header.number as i64 * KATE_SECONDS_PER_BLOCK),
+        )
     }
 }

--- a/adapters/avail/src/spec/mod.rs
+++ b/adapters/avail/src/spec/mod.rs
@@ -1,5 +1,5 @@
-use sov_rollup_interface::da::DaSpec;
 use crate::verifier::ChainValidityCondition;
+use sov_rollup_interface::da::DaSpec;
 
 pub mod address;
 pub mod block;
@@ -7,11 +7,11 @@ mod hash;
 pub mod header;
 pub mod transaction;
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct DaLayerSpec;
 
 impl DaSpec for DaLayerSpec {
-    type ValidityCondition =  ChainValidityCondition;
+    type ValidityCondition = ChainValidityCondition;
 
     type SlotHash = hash::AvailHash;
 

--- a/adapters/avail/src/verifier.rs
+++ b/adapters/avail/src/verifier.rs
@@ -1,7 +1,7 @@
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::zk::ValidityCondition;
-use borsh::{BorshDeserialize, BorshSerialize};
 use thiserror::Error;
 
 use crate::spec::DaLayerSpec;
@@ -12,7 +12,9 @@ pub enum ValidityConditionError {
     BlocksNotConsecutive,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, BorshDeserialize, BorshSerialize,
+)]
 /// A validity condition expressing that a chain of DA layer blocks is contiguous and canonical
 pub struct ChainValidityCondition {
     pub prev_hash: [u8; 32],
@@ -28,7 +30,7 @@ impl ValidityCondition for ChainValidityCondition {
         let mut combined_hashes: Vec<u8> = Vec::with_capacity(64);
         combined_hashes.extend_from_slice(self.txs_commitment.as_ref());
         combined_hashes.extend_from_slice(rhs.txs_commitment.as_ref());
-        
+
         let combined_root = sp_core_hashing::blake2_256(&combined_hashes);
 
         if self.block_hash != rhs.prev_hash {
@@ -36,8 +38,8 @@ impl ValidityCondition for ChainValidityCondition {
         }
 
         Ok(Self {
-            prev_hash: rhs.prev_hash, 
-            block_hash: rhs.block_hash, 
+            prev_hash: rhs.prev_hash,
+            block_hash: rhs.block_hash,
             txs_commitment: combined_root,
         })
     }
@@ -52,7 +54,7 @@ impl DaVerifier for Verifier {
 
     // Verify that the given list of blob transactions is complete and correct.
     // NOTE: Function return unit since application client already verifies application data.
-    fn verify_relevant_tx_list<SimpleHasher>(
+    fn verify_relevant_tx_list(
         &self,
         block_header: &<Self::Spec as DaSpec>::BlockHeader,
         txs: &[<Self::Spec as DaSpec>::BlobTransaction],


### PR DESCRIPTION
# Description
This PR updates the `presence` adapter to the latest nightly version of the Sovereign SDK. It also makes a few very minor changes:
- Remove duplicate information from README
- Rename to `sov-avail-adapter` to match the convention from the SDK


This PR is not intended to be merged (although it can be!) Rather, it's meant to show the differences between the code from https://github.com/Sovereign-Labs/sovereign-sdk/pull/631 and https://github.com/Sovereign-Labs/sovereign-sdk/pull/905